### PR TITLE
Add auth.user to profiles upon signup

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@chakra-ui/icons": "^2.0.8",
     "@chakra-ui/react": "^2.2.8",
-    "@chakra-ui/slider": "1.5.9",
+    "@chakra-ui/slider": "^1.5.9",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
     "@supabase/supabase-js": "^1.35.6",

--- a/src/App.js
+++ b/src/App.js
@@ -1,26 +1,45 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 // import logo from "./logo.svg";
 import "./App.css";
 import Navbar from "./Components/Navbar";
+import { supabase } from "./server/supabaseClient";
 import Auth from "./Components/Auth";
 import Moments from "./Components/Moments";
 import Footer from "./Components/Footer";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
 import ErrorPage from "./Components/ErrorPage";
 import AddMoment from "./Components/AddMoment";
 
 function App() {
+  const [session, setSession] = useState("");
+
+  useEffect(() => {
+    setSession(supabase.auth.session());
+
+    supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+    });
+  }, []);
+
   return (
     <div className="App">
-      <Navbar />
-      <Routes>
-        {/* to do: if logged in, take the user to home or display home component, if not, display auth and don't allow any other navigation*/}
-        <Route path="/" element={<Auth />} />
-        <Route path="/moments" element={<Moments />} />
-        <Route path="/add" element={<AddMoment />} />
-        <Route path="*" element={<ErrorPage />} />
-      </Routes>
-      <Footer />
+      {!session ? (
+        <Routes>
+          <Route path="/" element={<Auth />} />
+        </Routes>
+      ) : (
+        <>
+          <Navbar />
+          <Routes>
+            {/* to do: if logged in, take the user to home or display home component, if not, display auth and don't allow any other navigation*/}
+            <Route path="/" element={<Navigate to="/moments" />} />
+            <Route path="/moments" element={<Moments />} />
+            <Route path="/add" element={<AddMoment />} />
+            <Route path="*" element={<ErrorPage />} />
+          </Routes>
+          <Footer />
+        </>
+      )}
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Footer from "./Components/Footer";
 import { Routes, Route, Navigate } from "react-router-dom";
 import ErrorPage from "./Components/ErrorPage";
 import AddMoment from "./Components/AddMoment";
+import WelcomeProfile from "./Components/WelcomeProfile";
 
 function App() {
   const [session, setSession] = useState("");
@@ -35,6 +36,12 @@ function App() {
             <Route path="/" element={<Navigate to="/moments" />} />
             <Route path="/moments" element={<Moments />} />
             <Route path="/add" element={<AddMoment />} />
+            <Route
+              path="/welcome"
+              element={
+                <WelcomeProfile key={session.user.id} session={session} />
+              }
+            />
             <Route path="*" element={<ErrorPage />} />
           </Routes>
           <Footer />

--- a/src/Components/Auth.js
+++ b/src/Components/Auth.js
@@ -33,10 +33,13 @@ export default function Auth() {
   const handleSignUp = async (email, password) => {
     try {
       setLoading(true);
-      const { error } = await supabase.auth.signUp({
-        email,
-        password,
-      });
+      const { error } = await supabase.auth.signUp(
+        {
+          email,
+          password,
+        },
+        { redirectTo: "http://localhost:3000/welcome" }
+      );
       if (error) throw error;
 
       alert("Check your email for a verification link.");

--- a/src/Components/Auth.js
+++ b/src/Components/Auth.js
@@ -4,7 +4,7 @@ import {
   Input,
   InputGroup,
   Button,
-  Container,
+  Flex,
   VStack,
   HStack,
   Heading,
@@ -33,9 +33,13 @@ export default function Auth() {
   const handleSignUp = async (email, password) => {
     try {
       setLoading(true);
-      const { error } = await supabase.auth.signUp({ email, password });
+      const { error } = await supabase.auth.signUp({
+        email,
+        password,
+      });
       if (error) throw error;
-      alert("You now have an account.");
+
+      alert("Check your email for a verification link.");
     } catch (error) {
       alert(error.error_description || error.message);
     } finally {
@@ -46,7 +50,7 @@ export default function Auth() {
   const handleClick = () => setShow(!show);
 
   return (
-    <Container>
+    <Flex>
       <VStack>
         <Heading size="md">Sign in or sign up with your email below</Heading>
         <VStack>
@@ -96,6 +100,6 @@ export default function Auth() {
           </Button>
         </HStack>
       </VStack>
-    </Container>
+    </Flex>
   );
 }

--- a/src/Components/WelcomeProfile.js
+++ b/src/Components/WelcomeProfile.js
@@ -1,15 +1,31 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { supabase } from "../server/supabaseClient";
+import Moments from "./Moments";
+import {
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  useDisclosure,
+} from "@chakra-ui/react";
 
 export default function Account({ session }) {
   const [loading, setLoading] = useState(true);
   const [email, setEmail] = useState("");
+  let { isOpen, onOpen, onClose } = useDisclosure();
+  const navigate = useNavigate();
 
   useEffect(() => {
-    getProfile();
+    onOpen();
+    getAndSetProfile();
   }, [session]);
 
-  async function getProfile() {
+  async function getAndSetProfile() {
     try {
       setLoading(true);
       const user = supabase.auth.user();
@@ -27,6 +43,8 @@ export default function Account({ session }) {
       if (data) {
         setEmail(data.email);
       }
+
+      updateProfile();
     } catch (error) {
       alert(error.message);
     } finally {
@@ -34,14 +52,15 @@ export default function Account({ session }) {
     }
   }
 
-  async function updateProfile({ email }) {
+  async function updateProfile() {
     try {
       setLoading(true);
       const user = supabase.auth.user();
+      console.log("user-->", user);
 
       const updates = {
         id: user.id,
-        email,
+        email: user.email,
         updated_at: new Date(),
       };
 
@@ -59,37 +78,37 @@ export default function Account({ session }) {
     }
   }
 
+  function closeModal() {
+    onClose();
+    navigate("/moments");
+  }
+
   return (
     <div>
-      <h1>Hello</h1>
-      <div>
-        <label htmlFor="email">Email</label>
-        <input
-          id="email"
-          type="text"
-          value={email || ""}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-      </div>
-
-      <div>
-        <button
-          className="button block primary"
-          onClick={() => updateProfile({ email })}
-          disabled={loading}
-        >
-          {loading ? "Loading ..." : "Update"}
-        </button>
-      </div>
-
-      <div>
-        <button
-          className="button block"
-          onClick={() => supabase.auth.signOut()}
-        >
-          Sign Out
-        </button>
-      </div>
+      <Modal
+        isCentered
+        size="lg"
+        isOpen={isOpen}
+        onOpen={onOpen}
+        onClose={onClose}
+        onClick={closeModal}
+      >
+        <ModalOverlay bg="blackAlpha.300" backdropFilter="blur(10px)" />
+        <ModalContent>
+          <ModalHeader>welcome to moments</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            we can't wait for you to explore everything our app has to offer.
+            close this popup to create your first moment!
+          </ModalBody>
+          <ModalFooter>
+            <Button colorScheme="blue" mr={3} onClick={closeModal}>
+              Close
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+      <Moments />
     </div>
   );
 }

--- a/src/Components/WelcomeProfile.js
+++ b/src/Components/WelcomeProfile.js
@@ -1,16 +1,12 @@
 import { useState, useEffect } from "react";
-import { supabase } from "./supabaseClient";
+import { supabase } from "../server/supabaseClient";
 
 export default function Account({ session }) {
   const [loading, setLoading] = useState(true);
-  const [username, setUsername] = useState("");
-  const [website, setWebsite] = useState("");
-  const [avatar_url, setAvatarUrl] = useState("");
-  const [dogs, setDogs] = useState([]);
+  const [email, setEmail] = useState("");
 
   useEffect(() => {
     getProfile();
-    getDogs();
   }, [session]);
 
   async function getProfile() {
@@ -20,7 +16,7 @@ export default function Account({ session }) {
 
       let { data, error, status } = await supabase
         .from("profiles")
-        .select(`username, website, avatar_url`)
+        .select(`email`)
         .eq("id", user.id)
         .single();
 
@@ -29,9 +25,7 @@ export default function Account({ session }) {
       }
 
       if (data) {
-        setUsername(data.username);
-        setWebsite(data.website);
-        setAvatarUrl(data.avatar_url);
+        setEmail(data.email);
       }
     } catch (error) {
       alert(error.message);
@@ -40,16 +34,14 @@ export default function Account({ session }) {
     }
   }
 
-  async function updateProfile({ username, website, avatar_url }) {
+  async function updateProfile({ email }) {
     try {
       setLoading(true);
       const user = supabase.auth.user();
 
       const updates = {
         id: user.id,
-        username,
-        website,
-        avatar_url,
+        email,
         updated_at: new Date(),
       };
 
@@ -67,57 +59,23 @@ export default function Account({ session }) {
     }
   }
 
-  async function getDogs() {
-    try {
-      setLoading(true);
-
-      let { data, error, status } = await supabase
-        .from("dogs")
-        .select(`name, breed, age`);
-
-      if (error && status !== 406) {
-        throw error;
-      }
-
-      if (data) {
-        setDogs(data);
-      }
-    } catch (error) {
-      alert(error.message);
-    } finally {
-      setLoading(false);
-    }
-  }
-
   return (
-    <div className="form-widget">
+    <div>
+      <h1>Hello</h1>
       <div>
         <label htmlFor="email">Email</label>
-        <input id="email" type="text" value={session.user.email} disabled />
-      </div>
-      <div>
-        <label htmlFor="username">Name</label>
         <input
-          id="username"
+          id="email"
           type="text"
-          value={username || ""}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-      </div>
-      <div>
-        <label htmlFor="website">Website</label>
-        <input
-          id="website"
-          type="website"
-          value={website || ""}
-          onChange={(e) => setWebsite(e.target.value)}
+          value={email || ""}
+          onChange={(e) => setEmail(e.target.value)}
         />
       </div>
 
       <div>
         <button
           className="button block primary"
-          onClick={() => updateProfile({ username, website, avatar_url })}
+          onClick={() => updateProfile({ email })}
           disabled={loading}
         >
           {loading ? "Loading ..." : "Update"}
@@ -132,11 +90,6 @@ export default function Account({ session }) {
           Sign Out
         </button>
       </div>
-      {dogs.map((dog, idx) => (
-        <p key={idx}>
-          {dog.name} the {dog.breed} is {dog.age} years old.
-        </p>
-      ))}
     </div>
   );
 }

--- a/src/Components/WelcomeProfile.js
+++ b/src/Components/WelcomeProfile.js
@@ -1,0 +1,142 @@
+import { useState, useEffect } from "react";
+import { supabase } from "./supabaseClient";
+
+export default function Account({ session }) {
+  const [loading, setLoading] = useState(true);
+  const [username, setUsername] = useState("");
+  const [website, setWebsite] = useState("");
+  const [avatar_url, setAvatarUrl] = useState("");
+  const [dogs, setDogs] = useState([]);
+
+  useEffect(() => {
+    getProfile();
+    getDogs();
+  }, [session]);
+
+  async function getProfile() {
+    try {
+      setLoading(true);
+      const user = supabase.auth.user();
+
+      let { data, error, status } = await supabase
+        .from("profiles")
+        .select(`username, website, avatar_url`)
+        .eq("id", user.id)
+        .single();
+
+      if (error && status !== 406) {
+        throw error;
+      }
+
+      if (data) {
+        setUsername(data.username);
+        setWebsite(data.website);
+        setAvatarUrl(data.avatar_url);
+      }
+    } catch (error) {
+      alert(error.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function updateProfile({ username, website, avatar_url }) {
+    try {
+      setLoading(true);
+      const user = supabase.auth.user();
+
+      const updates = {
+        id: user.id,
+        username,
+        website,
+        avatar_url,
+        updated_at: new Date(),
+      };
+
+      let { error } = await supabase.from("profiles").upsert(updates, {
+        returning: "minimal", // Don't return the value after inserting
+      });
+
+      if (error) {
+        throw error;
+      }
+    } catch (error) {
+      alert(error.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function getDogs() {
+    try {
+      setLoading(true);
+
+      let { data, error, status } = await supabase
+        .from("dogs")
+        .select(`name, breed, age`);
+
+      if (error && status !== 406) {
+        throw error;
+      }
+
+      if (data) {
+        setDogs(data);
+      }
+    } catch (error) {
+      alert(error.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="form-widget">
+      <div>
+        <label htmlFor="email">Email</label>
+        <input id="email" type="text" value={session.user.email} disabled />
+      </div>
+      <div>
+        <label htmlFor="username">Name</label>
+        <input
+          id="username"
+          type="text"
+          value={username || ""}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+      </div>
+      <div>
+        <label htmlFor="website">Website</label>
+        <input
+          id="website"
+          type="website"
+          value={website || ""}
+          onChange={(e) => setWebsite(e.target.value)}
+        />
+      </div>
+
+      <div>
+        <button
+          className="button block primary"
+          onClick={() => updateProfile({ username, website, avatar_url })}
+          disabled={loading}
+        >
+          {loading ? "Loading ..." : "Update"}
+        </button>
+      </div>
+
+      <div>
+        <button
+          className="button block"
+          onClick={() => supabase.auth.signOut()}
+        >
+          Sign Out
+        </button>
+      </div>
+      {dogs.map((dog, idx) => (
+        <p key={idx}>
+          {dog.name} the {dog.breed} is {dog.age} years old.
+        </p>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
When a user signs up, we now have a flow that makes sure a profile is created for them in the profiles table.

1. user enters signup info
2. they receive confirmation email
3. upon confirmation, they're directed to /welcome, where a welcome modal is displayed
4. when /welcome mounts, we create a profile for the user.
5. in the background, we load all moments.
6. if they click close, they're redirected to /moments.
7. if they click anything else, the welcome modal closes, showing them all moments (but still @ /welcome)

changed some things around in App.js as well so make sure to review what's going on there.