### PR TITLE
Auth form enter

### DIFF
--- a/src/Components/Auth.js
+++ b/src/Components/Auth.js
@@ -4,6 +4,8 @@ import {
   Input,
   InputGroup,
   Button,
+  ButtonGroup,
+  FormControl,
   Flex,
   VStack,
   HStack,
@@ -20,29 +22,97 @@ export default function Auth() {
   const [show, setShow] = useState(false);
   const toast = useToast();
 
+  // toast alerts for login & signup
+  const ivalidLoginCredentials = () => {
+    toast({
+      title: "invalid credentials",
+      description: "please check your email and password and try again",
+      status: "error",
+      duration: 3000,
+      isClosable: true,
+      position: "top",
+    });
+  };
+
+  const loginSuccess = () => {
+    toast({
+      title: "logged in",
+      description: "enjoy the moment",
+      status: "success",
+      duration: 2000,
+      isClosable: true,
+      position: "top",
+    });
+  };
+
+  const userExists = () => {
+    toast({
+      title: "account already exists",
+      description:
+        "an account for this email address already exists. please log in to that account or request a password reset.",
+      status: "error",
+      duration: 3000,
+      isClosable: true,
+      position: "top",
+    });
+  };
+
+  const verifyEmailSent = () => {
+    toast({
+      title: "email sent",
+      description: "a verification email has been sent to the address provided",
+      status: "success",
+      duration: 2000,
+      isClosable: true,
+      position: "top",
+    });
+  };
+
+  const invalidEmailSignup = () => {
+    toast({
+      title: "invalid email",
+      description: "please enter a valid email and try again.",
+      status: "error",
+      duration: 3000,
+      isClosable: true,
+      position: "top",
+    });
+  };
+
+  const invalidPasswordSignup = (error) => {
+    toast({
+      title: "invalid password",
+      description: `${error.message.toLowerCase()}`,
+      status: "error",
+      duration: 3000,
+      isClosable: true,
+      position: "top",
+    });
+  };
+
+  const invalidCredentialsSignup = () => {
+    toast({
+      title: "invalid credentials",
+      description:
+        "please use a valid email and password with at least 6 characters",
+      status: "error",
+      duration: 3000,
+      isClosable: true,
+      position: "top",
+    });
+  };
+
+  // click handlers for login & signup
   const handleLogin = async (email, password) => {
     try {
       setLoading(true);
       const { error } = await supabase.auth.signIn({ email, password });
+      console.log("error", error);
       if (error) throw error;
-      toast({
-        title: "logged in",
-        description: "enjoy the moment",
-        status: "success",
-        duration: 2000,
-        isClosable: true,
-        position: "top",
-      });
+      loginSuccess();
     } catch (error) {
       console.error(error.error_description || error.message);
-      toast({
-        title: "invalid credentials",
-        description: "please check your email and password and try again.",
-        status: "error",
-        duration: 5000,
-        isClosable: true,
-        position: "top",
-      });
+      ivalidLoginCredentials();
     } finally {
       setLoading(false);
     }
@@ -59,15 +129,7 @@ export default function Auth() {
         .eq("email", lowercaseEmail);
 
       if (dbCheck.data.length !== 0) {
-        toast({
-          title: "account already exists",
-          description:
-            "an account for this email address already exists. please log in to that account or request a password reset.",
-          status: "error",
-          duration: 5000,
-          isClosable: true,
-          position: "top",
-        });
+        userExists();
       } else {
         const { error } = await supabase.auth.signUp(
           {
@@ -79,15 +141,7 @@ export default function Auth() {
 
         if (error) throw error;
 
-        toast({
-          title: "email sent",
-          description:
-            "a verification email has been sent to the address provided",
-          status: "success",
-          duration: 2000,
-          isClosable: true,
-          position: "top",
-        });
+        verifyEmailSent();
       }
     } catch (error) {
       console.error(error.error_description || error.message);
@@ -96,35 +150,13 @@ export default function Auth() {
         "Password should be at least 6 characters",
       ];
       if (error.message === commonMsgs[0]) {
-        toast({
-          title: "invalid email",
-          description: "please enter a valid email and try again.",
-          status: "error",
-          duration: 5000,
-          isClosable: true,
-          position: "top",
-        });
+        invalidEmailSignup();
       } else if (error.message === commonMsgs[1]) {
-        toast({
-          title: "invalid password",
-          description: `${error.message.toLowerCase()}`,
-          status: "error",
-          duration: 5000,
-          isClosable: true,
-          position: "top",
-        });
+        invalidPasswordSignup(error);
       }
 
       if (!commonMsgs.includes(error.message)) {
-        toast({
-          title: "invalid credentials",
-          description:
-            "please use a valid email and password with at least 6 characters",
-          status: "error",
-          duration: 5000,
-          isClosable: true,
-          position: "top",
-        });
+        invalidCredentialsSignup();
       }
     } finally {
       setLoading(false);
@@ -136,42 +168,44 @@ export default function Auth() {
   return (
     <Flex justifyContent="center" alignItems="center" height="50vh">
       <VStack>
-        <Box fontSize={["36px", "48px"]}>moments.</Box>
-        <Heading size="md">get started now</Heading>
-        <VStack>
-          {/**** email input ****/}
-          <Input
-            type="email"
-            placeholder="your email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-          {/**** password input w/ show/hide ****/}
-          <InputGroup size="md">
+        <Box fontSize={["36px", "48px"]}>vibe☑ </Box>
+        <Heading size="md">time to check in</Heading>
+        <FormControl isRequired>
+          <VStack>
+            {/**** email input ****/}
             <Input
-              pr="4.5rem"
-              type={show ? "text" : "password"}
-              placeholder="your password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              type="email"
+              placeholder="your email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
             />
-            <InputRightElement width="4.5rem">
-              <Button h="1.75rem" size="sm" onClick={showPw}>
-                {show ? "hide" : "show"}
-              </Button>
-            </InputRightElement>
-          </InputGroup>
-        </VStack>
-        <HStack>
+            {/**** password input w/ show/hide ****/}
+            <InputGroup size="md">
+              <Input
+                pr="4.5rem"
+                type={show ? "text" : "password"}
+                placeholder="your password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <InputRightElement width="4.5rem">
+                <Button h="1.75rem" size="sm" onClick={showPw}>
+                  {show ? "hide" : "show"}
+                </Button>
+              </InputRightElement>
+            </InputGroup>
+          </VStack>
+        </FormControl>
+        <ButtonGroup disabled={loading} h="1.75rem" size="sm">
           {/**** signup button ****/}
           <Button
             onClick={(e) => {
               e.preventDefault();
               handleSignUp(email, password);
             }}
-            disabled={loading}
-            h="1.75rem"
-            size="sm"
+            // disabled={loading}
+            // h="1.75rem"
+            // size="sm"
           >
             {loading ? "loading" : "sign up"}
           </Button>
@@ -181,13 +215,13 @@ export default function Auth() {
               e.preventDefault();
               handleLogin(email, password);
             }}
-            disabled={loading}
-            h="1.75rem"
-            size="sm"
+            // disabled={loading}
+            // h="1.75rem"
+            // size="sm"
           >
             {loading ? "loading" : "login"}
           </Button>
-        </HStack>
+        </ButtonGroup>
       </VStack>
     </Flex>
   );

--- a/src/Components/Auth.js
+++ b/src/Components/Auth.js
@@ -1,126 +1,62 @@
 import { useState } from "react";
 import { supabase } from "../server/supabaseClient";
+import LightDarkButton from "./LightDarkButton";
 import {
   Input,
   InputGroup,
   Button,
   ButtonGroup,
-  FormControl,
   Flex,
-  VStack,
-  HStack,
   Heading,
   InputRightElement,
   useToast,
   Box,
+  FormControl,
+  CircularProgress,
 } from "@chakra-ui/react";
+import { ViewOffIcon, ViewIcon } from "@chakra-ui/icons";
+import {
+  ivalidCredentialsLogin,
+  loginSuccess,
+  userExists,
+  verifyEmailSent,
+  invalidEmailSignup,
+  invalidPasswordSignup,
+  invalidCredentialsSignup,
+} from "./ToastAlerts/AuthFormAlerts";
 
 export default function Auth() {
-  const [loading, setLoading] = useState(false);
+  const [loadingLogin, setLoadingLogin] = useState(false);
+  const [loadingSignUp, setLoadingSignUp] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [show, setShow] = useState(false);
   const toast = useToast();
 
-  // toast alerts for login & signup
-  const ivalidLoginCredentials = () => {
-    toast({
-      title: "invalid credentials",
-      description: "please check your email and password and try again",
-      status: "error",
-      duration: 3000,
-      isClosable: true,
-      position: "top",
-    });
-  };
-
-  const loginSuccess = () => {
-    toast({
-      title: "logged in",
-      description: "enjoy the moment",
-      status: "success",
-      duration: 2000,
-      isClosable: true,
-      position: "top",
-    });
-  };
-
-  const userExists = () => {
-    toast({
-      title: "account already exists",
-      description:
-        "an account for this email address already exists. please log in to that account or request a password reset.",
-      status: "error",
-      duration: 3000,
-      isClosable: true,
-      position: "top",
-    });
-  };
-
-  const verifyEmailSent = () => {
-    toast({
-      title: "email sent",
-      description: "a verification email has been sent to the address provided",
-      status: "success",
-      duration: 2000,
-      isClosable: true,
-      position: "top",
-    });
-  };
-
-  const invalidEmailSignup = () => {
-    toast({
-      title: "invalid email",
-      description: "please enter a valid email and try again.",
-      status: "error",
-      duration: 3000,
-      isClosable: true,
-      position: "top",
-    });
-  };
-
-  const invalidPasswordSignup = (error) => {
-    toast({
-      title: "invalid password",
-      description: `${error.message.toLowerCase()}`,
-      status: "error",
-      duration: 3000,
-      isClosable: true,
-      position: "top",
-    });
-  };
-
-  const invalidCredentialsSignup = () => {
-    toast({
-      title: "invalid credentials",
-      description:
-        "please use a valid email and password with at least 6 characters",
-      status: "error",
-      duration: 3000,
-      isClosable: true,
-      position: "top",
-    });
-  };
+  const credsInvalid = password.length < 6 || email.length === 0; // very rudimentary validation check
 
   // click handlers for login & signup
   const handleLogin = async (email, password) => {
     try {
-      setLoading(true);
+      setLoadingLogin(true);
       const { error } = await supabase.auth.signIn({ email, password });
       console.log("error", error);
       if (error) throw error;
-      loginSuccess();
+      toast(loginSuccess());
     } catch (error) {
       console.error(error.error_description || error.message);
-      ivalidLoginCredentials();
+      toast(ivalidCredentialsLogin());
     } finally {
-      setLoading(false);
+      setEmail("");
+      setPassword("");
+      setShow(false);
+      setLoadingLogin(false);
     }
   };
 
   const handleSignUp = async (email, password) => {
     try {
-      setLoading(true);
+      setLoadingSignUp(true);
       let lowercaseEmail = email.toLowerCase();
 
       const dbCheck = await supabase
@@ -129,7 +65,7 @@ export default function Auth() {
         .eq("email", lowercaseEmail);
 
       if (dbCheck.data.length !== 0) {
-        userExists();
+        toast(userExists());
       } else {
         const { error } = await supabase.auth.signUp(
           {
@@ -141,7 +77,7 @@ export default function Auth() {
 
         if (error) throw error;
 
-        verifyEmailSent();
+        toast(verifyEmailSent());
       }
     } catch (error) {
       console.error(error.error_description || error.message);
@@ -150,79 +86,108 @@ export default function Auth() {
         "Password should be at least 6 characters",
       ];
       if (error.message === commonMsgs[0]) {
-        invalidEmailSignup();
+        toast(invalidEmailSignup());
       } else if (error.message === commonMsgs[1]) {
-        invalidPasswordSignup(error);
+        toast(invalidPasswordSignup(error));
       }
 
       if (!commonMsgs.includes(error.message)) {
-        invalidCredentialsSignup();
+        toast(invalidCredentialsSignup());
       }
     } finally {
-      setLoading(false);
+      setEmail("");
+      setPassword("");
+      setShow(false);
+      setLoadingSignUp(false);
     }
   };
 
-  const showPw = () => setShow(!show);
-
   return (
-    <Flex justifyContent="center" alignItems="center" height="50vh">
-      <VStack>
-        <Box fontSize={["36px", "48px"]}>vibe☑ </Box>
-        <Heading size="md">time to check in</Heading>
-        <FormControl isRequired>
-          <VStack>
-            {/**** email input ****/}
-            <Input
-              type="email"
-              placeholder="your email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
-            {/**** password input w/ show/hide ****/}
-            <InputGroup size="md">
-              <Input
-                pr="4.5rem"
-                type={show ? "text" : "password"}
-                placeholder="your password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-              <InputRightElement width="4.5rem">
-                <Button h="1.75rem" size="sm" onClick={showPw}>
-                  {show ? "hide" : "show"}
+    <Box>
+      <Box textAlign="right" py={4} mr="2%">
+        <LightDarkButton />
+      </Box>
+      <Flex justifyContent="center" width="full" align="center">
+        <Box
+          p={8}
+          maxWidth="500px"
+          borderWidth={1}
+          borderRadius={8}
+          boxShadow="md"
+        >
+          <Box textAlign="center">
+            <Box fontSize={["36px", "48px"]}>vibe☑</Box>
+            <Heading size="md">time to check in</Heading>
+          </Box>
+          <Box my={4} textAlign="left">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleLogin(email, password);
+              }}
+            >
+              <FormControl isRequired>
+                <Input
+                  type="email"
+                  placeholder="your email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                />
+              </FormControl>
+              <FormControl mt={6} isRequired>
+                <InputGroup size="md">
+                  <Input
+                    type={show ? "text" : "password"}
+                    placeholder="your password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                  />
+                  <InputRightElement width="4.5rem">
+                    <Button
+                      h="1.75rem"
+                      size="sm"
+                      onClick={() => setShow(!show)}
+                    >
+                      {show ? <ViewOffIcon /> : <ViewIcon />}
+                    </Button>
+                  </InputRightElement>
+                </InputGroup>
+              </FormControl>
+              <ButtonGroup size="md" mt={4}>
+                <Button type="submit" disabled={credsInvalid}>
+                  {loadingLogin ? (
+                    <CircularProgress
+                      isIndeterminate
+                      size="1.75rem"
+                      color="tomato"
+                    />
+                  ) : (
+                    "login"
+                  )}
                 </Button>
-              </InputRightElement>
-            </InputGroup>
-          </VStack>
-        </FormControl>
-        <ButtonGroup disabled={loading} h="1.75rem" size="sm">
-          {/**** signup button ****/}
-          <Button
-            onClick={(e) => {
-              e.preventDefault();
-              handleSignUp(email, password);
-            }}
-            // disabled={loading}
-            // h="1.75rem"
-            // size="sm"
-          >
-            {loading ? "loading" : "sign up"}
-          </Button>
-          {/**** login button ****/}
-          <Button
-            onClick={(e) => {
-              e.preventDefault();
-              handleLogin(email, password);
-            }}
-            // disabled={loading}
-            // h="1.75rem"
-            // size="sm"
-          >
-            {loading ? "loading" : "login"}
-          </Button>
-        </ButtonGroup>
-      </VStack>
-    </Flex>
+                <Button
+                  variant="outline"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleSignUp(email, password);
+                  }}
+                  disabled={credsInvalid}
+                >
+                  {loadingSignUp ? (
+                    <CircularProgress
+                      isIndeterminate
+                      size="1.75rem"
+                      color="tomato"
+                    />
+                  ) : (
+                    "sign up"
+                  )}
+                </Button>
+              </ButtonGroup>
+            </form>
+          </Box>
+        </Box>
+      </Flex>
+    </Box>
   );
 }

--- a/src/Components/Auth.js
+++ b/src/Components/Auth.js
@@ -16,7 +16,7 @@ import {
 } from "@chakra-ui/react";
 import { ViewOffIcon, ViewIcon } from "@chakra-ui/icons";
 import {
-  ivalidCredentialsLogin,
+  invalidCredentialsLogin,
   loginSuccess,
   userExists,
   verifyEmailSent,
@@ -45,7 +45,7 @@ export default function Auth() {
       toast(loginSuccess());
     } catch (error) {
       console.error(error.error_description || error.message);
-      toast(ivalidCredentialsLogin());
+      toast(invalidCredentialsLogin());
     } finally {
       setEmail("");
       setPassword("");

--- a/src/Components/Settings/SettingsScreen.js
+++ b/src/Components/Settings/SettingsScreen.js
@@ -15,6 +15,7 @@ import {
 } from "@chakra-ui/react";
 import LightDarkButton from "../LightDarkButton";
 import { supabase } from "../../server/supabaseClient";
+import { passwordUpdated, emailUpdated } from "../ToastAlerts/AuthFormAlerts";
 
 const SettingsScreen = (props) => {
   const { colorMode } = useColorMode();
@@ -39,12 +40,12 @@ const SettingsScreen = (props) => {
       if (error) {
         throw error;
       }
+      toast(emailUpdated());
     } catch (error) {
       alert(error.message);
     } finally {
       setEmailLoading(false);
     }
-    alert("You have updated your email");
   }
   async function updatePassword() {
     try {
@@ -58,13 +59,7 @@ const SettingsScreen = (props) => {
       if (error) {
         throw error;
       }
-      toast({
-        title: "you have updated your password",
-        status: "success",
-        duration: 2000,
-        isClosable: true,
-        position: "top",
-      });
+      toast(passwordUpdated());
     } catch (error) {
       alert(error.message);
     } finally {
@@ -80,8 +75,8 @@ const SettingsScreen = (props) => {
   }, []);
 
   return (
-    <Container zIndex='hide' >
-      <VStack alignItems="stretch" p="5" pt="10" >
+    <Container zIndex="hide">
+      <VStack alignItems="stretch" p="5" pt="10">
         {pageLoading ? (
           <>
             <Skeleton h="20px" />

--- a/src/Components/Settings/SettingsScreen.js
+++ b/src/Components/Settings/SettingsScreen.js
@@ -11,6 +11,7 @@ import {
   HStack,
   Spinner,
   Skeleton,
+  useToast,
 } from "@chakra-ui/react";
 import LightDarkButton from "../LightDarkButton";
 import { supabase } from "../../server/supabaseClient";
@@ -24,12 +25,13 @@ const SettingsScreen = (props) => {
   const [emailLoading, setEmailLoading] = useState(false);
   const [passwordLoading, setPasswordLoading] = useState(false);
   const [pageLoading, setPageLoading] = useState(false);
+  const toast = useToast();
 
   async function updateEmail() {
     try {
       setEmailLoading(true);
 
-      const { data, error } = await supabase.auth.update({
+      const { error } = await supabase.auth.update({
         email: email,
         updated_at: new Date(),
       });
@@ -42,13 +44,13 @@ const SettingsScreen = (props) => {
     } finally {
       setEmailLoading(false);
     }
-    alert('You have updated your email')
+    alert("You have updated your email");
   }
   async function updatePassword() {
     try {
       setPasswordLoading(true);
 
-      const { data, error } = await supabase.auth.update({
+      const { error } = await supabase.auth.update({
         password: password,
         updated_at: new Date(),
       });
@@ -56,12 +58,18 @@ const SettingsScreen = (props) => {
       if (error) {
         throw error;
       }
+      toast({
+        title: "you have updated your password",
+        status: "success",
+        duration: 2000,
+        isClosable: true,
+        position: "top",
+      });
     } catch (error) {
       alert(error.message);
     } finally {
       setPasswordLoading(false);
     }
-    alert('You have updated your password')
   }
 
   useEffect(() => {

--- a/src/Components/ToastAlerts/AuthFormAlerts.js
+++ b/src/Components/ToastAlerts/AuthFormAlerts.js
@@ -1,4 +1,4 @@
-export const ivalidCredentialsLogin = () => {
+export const invalidCredentialsLogin = () => {
   return {
     title: "invalid credentials",
     description: "please check your email and password and try again",

--- a/src/Components/ToastAlerts/AuthFormAlerts.js
+++ b/src/Components/ToastAlerts/AuthFormAlerts.js
@@ -76,3 +76,23 @@ export const invalidCredentialsSignup = () => {
     position: "top",
   };
 };
+
+export const passwordUpdated = () => {
+  return {
+    title: "you have updated your password",
+    status: "success",
+    duration: 2000,
+    isClosable: true,
+    position: "top",
+  };
+};
+
+export const emailUpdated = () => {
+  return {
+    title: "a change request has been sent to the address provided",
+    status: "success",
+    duration: 2000,
+    isClosable: true,
+    position: "top",
+  };
+};

--- a/src/Components/ToastAlerts/AuthFormAlerts.js
+++ b/src/Components/ToastAlerts/AuthFormAlerts.js
@@ -1,0 +1,78 @@
+export const ivalidCredentialsLogin = () => {
+  return {
+    title: "invalid credentials",
+    description: "please check your email and password and try again",
+    status: "error",
+    duration: 3000,
+    isClosable: true,
+    position: "top",
+  };
+};
+
+export const loginSuccess = () => {
+  return {
+    title: "logged in",
+    description: "enjoy the moment",
+    status: "success",
+    duration: 2000,
+    isClosable: true,
+    position: "top",
+  };
+};
+
+export const userExists = () => {
+  return {
+    title: "account already exists",
+    description:
+      "an account for this email address already exists. please log in to that account or request a password reset.",
+    status: "error",
+    duration: 3000,
+    isClosable: true,
+    position: "top",
+  };
+};
+
+export const verifyEmailSent = () => {
+  return {
+    title: "email sent",
+    description: "a verification email has been sent to the address provided",
+    status: "success",
+    duration: 2000,
+    isClosable: true,
+    position: "top",
+  };
+};
+
+export const invalidEmailSignup = () => {
+  return {
+    title: "invalid email",
+    description: "please enter a valid email and try again.",
+    status: "error",
+    duration: 3000,
+    isClosable: true,
+    position: "top",
+  };
+};
+
+export const invalidPasswordSignup = (error) => {
+  return {
+    title: "invalid password",
+    description: `${error.message.toLowerCase()}`,
+    status: "error",
+    duration: 3000,
+    isClosable: true,
+    position: "top",
+  };
+};
+
+export const invalidCredentialsSignup = () => {
+  return {
+    title: "invalid credentials",
+    description:
+      "please use a valid email and password with at least 6 characters",
+    status: "error",
+    duration: 3000,
+    isClosable: true,
+    position: "top",
+  };
+};


### PR DESCRIPTION
Refactored the AuthForm:
- Default action upon hitting 'enter' is login
- Added light/dark mode toggle
- Default 'required field' checks and browser alerts on email & pw
- Moved content of toast alerts to their own file
- Buttons are now disabled if email.length === 0 or password.length < 6
- Split loading state into two so we can have spinners on one button at a time

Also added two successful toast alerts in SettingsScreen for email and pw changes.